### PR TITLE
Update ndofdev.c

### DIFF
--- a/ndofdev.c
+++ b/ndofdev.c
@@ -122,6 +122,7 @@ int ndof_init_first(NDOF_Device *in_out_dev, void *param)
                         (ID.product == 0xc62F) || // SpaceMouse Wireless (receiver) (untested)
                         (ID.product == 0xc631) || // Spacemouse Wireless (untested)
                         (ID.product == 0xc632) || // SpacemousePro Wireless (untested)
+			(ID.product == 0xc635) || // Spacemouse Compact (untested)    
                         0
                     )
                 ))


### PR DESCRIPTION
Added the ID for my new Spacemouse Compact, maybe you like to integrate it
12:40:38 kernel: hid-generic 0003:256F:C635.0008: input,hidraw4: USB HID v1.11 Multi-Axis Controller [3Dconnexion SpaceMouse Compact] on usb-0000:11:00.3-2.4/input0
12:40:38 kernel: input: 3Dconnexion SpaceMouse Compact as /devices/pci0000:00/0000:00:07.1/0000:11:00.3/usb5/5-2/5-2.4/5-2.4:1.0/0003:256F:C635.0008/input/input20
12:40:37 kernel: usb 5-2.4: Manufacturer: 3Dconnexion